### PR TITLE
Add Pusher worker testbench

### DIFF
--- a/testbench/README.md
+++ b/testbench/README.md
@@ -1,6 +1,7 @@
 # Testbench Vite Project
 
-This directory contains a minimal [Vite](https://vitejs.dev/) setup for local testing.
+This directory contains a small [Vite](https://vitejs.dev/) application used to
+interact with the Pusher compatible Cloudflare Worker from the root project.
 
 ## Available Scripts
 
@@ -8,4 +9,7 @@ This directory contains a minimal [Vite](https://vitejs.dev/) setup for local te
 - `npm run build` – Build the project for production.
 - `npm run preview` – Preview the production build.
 
-The app simply logs a message to the console and displays text on the page.
+When the dev server starts the app will attempt to connect to the Worker running
+on `localhost:8787` using the default credentials from `wrangler.jsonc`. A
+simple UI lets you send messages to `test-channel` and shows received events in
+the log panel.

--- a/testbench/index.html
+++ b/testbench/index.html
@@ -3,10 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Vite App</title>
+  <title>Pusher Testbench</title>
 </head>
 <body>
-  <div id="app">Hello Vite!</div>
+  <h1>Pusher Testbench</h1>
+  <div>
+    <label>Message: <input type="text" id="message-input" /></label>
+    <button id="send-btn">Send</button>
+  </div>
+  <pre id="log"></pre>
+  <script src="https://unpkg.com/pusher-js@8.4.0/dist/web/pusher.min.js"></script>
   <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/testbench/src/main.js
+++ b/testbench/src/main.js
@@ -1,1 +1,54 @@
-console.log('Vite project loaded');
+const APP_ID = 'your-app-id';
+const APP_KEY = 'your-app-key';
+const HOST = 'localhost';
+const PORT = 8787;
+const CHANNEL = 'test-channel';
+const EVENT = 'test-event';
+
+function log(msg) {
+  const el = document.getElementById('log');
+  el.textContent += msg + '\n';
+}
+
+log('Connecting to worker...');
+
+const pusher = new Pusher(APP_KEY, {
+  wsHost: HOST,
+  wsPort: PORT,
+  wssPort: PORT,
+  wsPath: `/app/${APP_KEY}`,
+  forceTLS: false,
+  disableStats: true,
+});
+
+pusher.connection.bind('state_change', ({ current }) => {
+  log('Connection state: ' + current);
+});
+
+pusher.connection.bind('error', (err) => {
+  log('Connection error: ' + JSON.stringify(err));
+});
+
+const channel = pusher.subscribe(CHANNEL);
+
+channel.bind(EVENT, (data) => {
+  log('Received: ' + JSON.stringify(data));
+});
+
+const input = document.getElementById('message-input');
+const sendBtn = document.getElementById('send-btn');
+
+sendBtn.addEventListener('click', async () => {
+  const message = input.value;
+  log('Sending: ' + message);
+  await fetch(`http://${HOST}:${PORT}/apps/${APP_ID}/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: EVENT,
+      data: message,
+      channels: [CHANNEL],
+    }),
+  });
+  input.value = '';
+});


### PR DESCRIPTION
## Summary
- add a simple Vite UI for testing the Pusher-compatible worker
- log received events and allow sending new events
- update README with usage notes

## Testing
- `npm --prefix testbench install`
- `npm --prefix testbench run build`

------
https://chatgpt.com/codex/tasks/task_e_6855ce88eab48322862c0bd46739b430